### PR TITLE
Initializer should not have `func` keyword

### DIFF
--- a/Source/CuckooGeneratorFramework/Generators/Generator_r3.swift
+++ b/Source/CuckooGeneratorFramework/Generators/Generator_r3.swift
@@ -87,6 +87,7 @@ struct Generator_r3: Generator {
         guard accessibility != .Private else { return [] }
         var output: [String] = []
         let rawName = name.takeUntilStringOccurs("(") ?? ""
+        let isInitializer = rawName == "init"
         
         let fullyQualifiedName = fullyQualifiedMethodName(name, parameters: parameters, returnSignature: returnSignature)
         let parametersSignature = methodParametersSignature(parameters)
@@ -107,7 +108,7 @@ struct Generator_r3: Generator {
         managerCall += prepareEscapingParametersForMethodCall(parameters)
         
         output += ""
-        output += "\(getAccessibilitySourceName(accessibility))\(isOverriding ? "override " : "")func \(rawName)(\(parametersSignature))\(returnSignature) {"
+        output += "\(getAccessibilitySourceName(accessibility))\(isOverriding ? "override " : "")\(isInitializer ? "" : "func " )\(rawName)(\(parametersSignature))\(returnSignature) {"
         output += "    return \(managerCall)"
         output += "}"
         return output


### PR DESCRIPTION
I actually thought of declaring `isInitializer` like 

``` swift
let isInitializer = ["init", "init?"].contains(rawName)
```

But this is kind of different issue. 
Failable initializer looses question mark when generated as a class method name.
So this code `init?(a: Int) { return nil }` will result with `token.name` like this `init(a:)`
Not yet sure if this is an issue though.
